### PR TITLE
Update folder_create_modal.php

### DIFF
--- a/modals/folder_create_modal.php
+++ b/modals/folder_create_modal.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog">
         <div class="modal-content bg-dark">
             <div class="modal-header">
-                <h5 class="modal-title"><i class="fa fa-fw fa-folder-plus mr-2"></i>Creating folder in <strong><?php if($get_folder_id > 0) { echo $folder['folder_name']; } else { echo "/"; } ?></strong></h5>
+                <h5 class="modal-title"><i class="fa fa-fw fa-folder-plus mr-2"></i>Creating folder in <strong><?php if($get_folder_id > 0) { echo $folder_path[count($folder_path)-1]['folder_name']; } else { echo "/"; } ?></strong></h5>
                 <button type="button" class="close text-white" data-dismiss="modal">
                     <span>&times;</span>
                 </button>


### PR DESCRIPTION
$folder['folder_name']; did not exist in the scope of where folder_create_modal.php was being required in the client_files.php and client_documents.php leading to null array pointer exception. While dirty the new way will reliably retrieve the name of the current folder the user is browsing to and correctly name the modal.

![image](https://github.com/user-attachments/assets/d03e4eef-bd3a-481d-bad6-6ab36140b094)


![image](https://github.com/user-attachments/assets/63ed8218-10df-4020-a1bd-41c43127c533)

